### PR TITLE
Change docker image to <machine-name>-node

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_ARCH%%-node:0.10.38
+FROM resin/%%RESIN_MACHINE_NAME%%-node:0.10.40
 
 # Note we added the python dependencies after resin-wifi-connect's deps.
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
resin/%%RESIN_ARCH%%-node will point to deprecated node images. It should be resin/%%RESIN_MACHINE_NAME%%-node.

The latest node version for rpi is 0.10.40. We also have Node v4.0.0 for rpi.
